### PR TITLE
Fix Parallel.For to read items from collection as needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,20 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.0</version>
+        <configuration>
+          <source>7</source>
+          <target>7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/tantaman/commons/concurrent/Parallel.java
+++ b/src/main/java/com/tantaman/commons/concurrent/Parallel.java
@@ -29,6 +29,8 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Parallel {
     private static final int NUM_CORES = Runtime.getRuntime().availableProcessors();
@@ -37,11 +39,19 @@ public class Parallel {
     private static final ForkJoinPool fjPool = new ForkJoinPool(NUM_CORES, ForkJoinPool.defaultForkJoinWorkerThreadFactory, null, true);
 
     public static <T> void For(final Iterable<T> elements, final Operation<T> operation) {
-    	try {
-			forPool.invokeAll(createCallables(elements, operation));
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
+        for (final T element : elements) {
+            forPool.submit(new Callable<Void>() {
+                @Override
+                public Void call() {
+                    try {
+                        operation.perform(element);
+                    } catch (Exception e) {
+                        Logger.getLogger(Parallel.class.getName()).log(Level.SEVERE, "Exception during execution of parallel task", e);
+                    }
+                    return null;
+                }
+            });
+        }
     }
     
     public static <T> void ForFJ(final Iterable<T> elements, final Operation<T> operation) {


### PR DESCRIPTION
The Iterable I was passing to For was a database cursor with hundreds of thousands of records. With the current code first all of the elements would be read and then the parallel tasks would be kicked off. At some point this could lead to memory exhaustion though I didn't face it. A better approach is to read the elements from the collection as needed.

ForFJ does the same thing and likely needs to be updated as well.
